### PR TITLE
Setting up aws profile use and terraform variables

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,4 @@
+provider "aws" {
+  region  = "us-west-2"
+  profile = var.profile
+}

--- a/terraform/variable.tf
+++ b/terraform/variable.tf
@@ -1,3 +1,0 @@
-variable "region" {
-  default = "us-west-2"
-}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,4 @@
+
+variable "profile" {
+
+}

--- a/terraform/vpc.tf
+++ b/terraform/vpc.tf
@@ -1,7 +1,3 @@
-provider "aws" {
- region = "var.region"
-}
-
 module "vpc" {
   source = "terraform-aws-modules/vpc/aws"
 


### PR DESCRIPTION
I put profile variable reference in main.tf so when executing terraform scripts, it will prompt you to use a local aws profile. Everyone will need to setup local aws profile so they can test scripts in local aws and cory's "production" aws.